### PR TITLE
bugfix: fix profile dropdown

### DIFF
--- a/frontend/src/components/NavBar/NavBar.jsx
+++ b/frontend/src/components/NavBar/NavBar.jsx
@@ -14,7 +14,7 @@ export default function NavBar() {
     const [isScrolled, setIsScrolled] = useState(false);
     const { authState } = useContext(UserContext);
     const [validated] = authState;
-    const [profileClicked, setProfileClicked] = useState(true);
+    const [profileClicked, setProfileClicked] = useState(false);
 
     // const {validated, setValidated }= UseValidateJWT();
 

--- a/frontend/src/components/NavBar/NavBar.jsx
+++ b/frontend/src/components/NavBar/NavBar.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { useState, useEffect, useContext } from 'react';
+import { useState, useEffect, useContext, useRef } from 'react';
 import { AiOutlineUser } from 'react-icons/ai';
 import styles from './NavBar.module.css';
 // import UseValidateJWT from '../../services/UseValidateJWT.jsx';
@@ -15,6 +15,7 @@ export default function NavBar() {
     const { authState } = useContext(UserContext);
     const [validated] = authState;
     const [profileClicked, setProfileClicked] = useState(false);
+    const dropdownRef = useRef(null);
 
     // const {validated, setValidated }= UseValidateJWT();
 
@@ -32,6 +33,20 @@ export default function NavBar() {
 
         return () => {
             window.removeEventListener('scroll', handleScroll);
+        };
+    }, []);
+
+    useEffect(() => {
+        const handleClickOutside = (event) => {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+                setProfileClicked(false);
+            }
+        };
+
+        document.addEventListener('click', handleClickOutside);
+
+        return () => {
+            document.removeEventListener('click', handleClickOutside);
         };
     }, []);
 
@@ -90,7 +105,7 @@ export default function NavBar() {
                 )}
 
                 {profileClicked && (
-                    <ProfileDropdown handleOnClick={handleOnClick} />
+                    <ProfileDropdown handleOnClick={handleOnClick} ref={dropdownRef} />
                 )}
                 <div
                     className={header}

--- a/frontend/src/components/NavBar/NavBar.jsx
+++ b/frontend/src/components/NavBar/NavBar.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { useState, useEffect, useContext, useRef } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import { AiOutlineUser } from 'react-icons/ai';
 import styles from './NavBar.module.css';
 // import UseValidateJWT from '../../services/UseValidateJWT.jsx';
@@ -14,8 +14,7 @@ export default function NavBar() {
     const [isScrolled, setIsScrolled] = useState(false);
     const { authState } = useContext(UserContext);
     const [validated] = authState;
-    const [profileClicked, setProfileClicked] = useState(false);
-    const dropdownRef = useRef(null);
+    const [profileClicked, setProfileClicked] = useState(true);
 
     // const {validated, setValidated }= UseValidateJWT();
 
@@ -33,20 +32,6 @@ export default function NavBar() {
 
         return () => {
             window.removeEventListener('scroll', handleScroll);
-        };
-    }, []);
-
-    useEffect(() => {
-        const handleClickOutside = (event) => {
-            if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
-                setProfileClicked(false);
-            }
-        };
-
-        document.addEventListener('click', handleClickOutside);
-
-        return () => {
-            document.removeEventListener('click', handleClickOutside);
         };
     }, []);
 
@@ -105,7 +90,7 @@ export default function NavBar() {
                 )}
 
                 {profileClicked && (
-                    <ProfileDropdown handleOnClick={handleOnClick} ref={dropdownRef} />
+                    <ProfileDropdown handleOnClick={handleOnClick} />
                 )}
                 <div
                     className={header}

--- a/frontend/src/components/NavBar/ProfileDropdown.jsx
+++ b/frontend/src/components/NavBar/ProfileDropdown.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable react/prop-types */
-import { useContext } from 'react';
+import { useEffect, useRef, useContext } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import styles from './ProfileDropdown.module.css';
 import { UserContext } from '../../context/UserContext.jsx';
@@ -27,34 +27,55 @@ export default function ProfileDropdown({ handleOnClick }) {
         navigate('/');
     };
 
+    const dropdownRef = useRef(null);
+
+    useEffect(() => {
+        // Function to handle clicks outside of the dropdown
+        function handleClickOutside(event) {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+                handleOnClick();
+            }
+        }
+
+        // Add event listener when component mounts
+        document.addEventListener('mousedown', handleClickOutside);
+
+        // Cleanup event listener when component unmounts
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [handleOnClick]);
+
     return (
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
         <div className={styles.background} onClick={handleOnClick}>
-            <div className={styles.container}>
-                <div className={styles.content}>
-                    <p className={styles.title}>
-                        {name ? `Hi ${name}!` : 'Welcome!'}
-                    </p>
-                    <p className={styles.email}>{email}</p>
-                    <div className={styles.links}>
-                        <Link to='/saved-courses' className={styles.link}>
-                            <span className={styles.text}>Saved Courses</span>
-                        </Link>
-                        <Link to='/my-reviews' className={styles.link}>
-                            <span className={styles.text}>Reviews</span>
-                        </Link>
-                        <Link to='/manage-account' className={styles.link}>
-                            <span className={styles.text}>Manage Account</span>
-                        </Link>
+            <div ref={dropdownRef} className={styles.container}>
+                <div className={styles.container}>
+                    <div className={styles.content}>
+                        <p className={styles.title}>
+                            {name ? `Hi ${name}!` : 'Welcome!'}
+                        </p>
+                        <p className={styles.email}>{email}</p>
+                        <div className={styles.links}>
+                            <Link to='/saved-courses' className={styles.link}>
+                                <span className={styles.text}>Saved Courses</span>
+                            </Link>
+                            <Link to='/my-reviews' className={styles.link}>
+                                <span className={styles.text}>Reviews</span>
+                            </Link>
+                            <Link to='/manage-account' className={styles.link}>
+                                <span className={styles.text}>Manage Account</span>
+                            </Link>
+                        </div>
+                        <button
+                            to='/'
+                            type='button'
+                            className={styles.signout}
+                            onClick={handleLogout}
+                        >
+                            <span className={styles.text}>Logout</span>
+                        </button>
                     </div>
-                    <button
-                        to='/'
-                        type='button'
-                        className={styles.signout}
-                        onClick={handleLogout}
-                    >
-                        <span className={styles.text}>Logout</span>
-                    </button>
                 </div>
             </div>
         </div>

--- a/frontend/src/components/NavBar/ProfileDropdown.module.css
+++ b/frontend/src/components/NavBar/ProfileDropdown.module.css
@@ -14,8 +14,8 @@
 	/* height: 160px; */
 	border-radius: 8px;
 	position: absolute;
-	top: 70px;
-	right: 90px;
+	top: calc(100%);
+	right: 10px;
 	background-color: #FFFFFF;
 	box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
 	border: 1px solid rgba(255, 255, 255, 0.366);


### PR DESCRIPTION
The profile menu closes whenever I click anywhere outside. I added an event listener in ProfileDropdown.jsx, which properly closes the dropdown when the user clicks anywhere else on the screen. This caused dropdown itself to have shifted for some reason so I made some small changes to the .container in the ProfileDropdown.css file to account for this.

![chrome_DhNwIKfprz](https://github.com/MingCWang/deiseval/assets/113255492/b62dbcc9-61e7-4f57-8837-fbc1b648df99)

Closes Issue #93 